### PR TITLE
feat: lower FSharp.Core requirements

### DIFF
--- a/src/Faqt/Faqt.fsproj
+++ b/src/Faqt/Faqt.fsproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.400" />
+    <PackageReference Update="FSharp.Core" Version="5.0.2" />
     <PackageReference Include="FracturedJson" Version="4.0.2" />
     <PackageReference Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />

--- a/src/Faqt/SubjectName.fs
+++ b/src/Faqt/SubjectName.fs
@@ -265,7 +265,7 @@ module internal SubjectName =
             |> Seq.skip (origin.LineNumber - 1)
             |> Seq.scan
                 (fun (countsLeft: Map<_, _>, _) line ->
-                    if countsLeft.Values |> Seq.forall ((=) 0) then
+                    if countsLeft |> Map.forall (fun _ v -> v = 0) then
                         countsLeft, None
                     else
                         let newCountsLeft =


### PR DESCRIPTION
Hello @cmeeren,

This PR is a suggestion I choose to make it via a PR instead of an issue because it is easier to showcase the impacted code.

I am currently exploring writing test for .NET and found your library. While giving it a try, I had this warning:

```text
warning NU1605: Detected package downgrade: FSharp.Core from 7.0.400 to 5.0.2. Reference the package directly from the project to select a different version. 
warning NU1605:  Ionide.XmlDocFormatter.Tests -> Faqt 4.0.0 -> FSharp.Core (>= 7.0.400) 
warning NU1605:  Ionide.XmlDocFormatter.Tests -> FSharp.Core (>= 5.0.2)
```

This is happening because when creating a library I make FSharp.Core requirements as low as possible and in general I use FSharp.Core 5.0.2 because it has most of the goodies that are needed now days.

I am following the recommendation from F# Compiler Guide:

> As an F# package author, you also need to make this decision with respect to FSharp.Core:
> 
> - Targeting an earlier version of FSharp.Core increases your reach because older codebases can use it without issue
> - Targeting a newer version of FSharp.Core lets you use and extend newer features
>
> This decision is critical, because it can have a network effect. If you choose a higher FSharp.Core version, then that also becomes a dependency for any other package that may depend on your package.

In my projects, I am using central package management which allows to handle versions for the packages at a single place instead of having to update each project individually. Because of these 2 reasons, I am getting the warning mentioned above when adding Faqt. 

While looking at Faqt code, I discovered that there was only 1 place which needed a more recent version of FSharp.Core so I think it can be good to make the proposed change. It also means that Faqt can be used by a wider set of project without requirement then to depends on a newer version of FSharp.Core.