### PR TITLE
Update FracturedJson to 4.0.3

### DIFF
--- a/src/Faqt/Faqt.fsproj
+++ b/src/Faqt/Faqt.fsproj
@@ -49,7 +49,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="5.0.2" />
-    <PackageReference Include="FracturedJson" Version="4.0.2" />
+    <PackageReference Include="FracturedJson" Version="4.0.3" />
     <PackageReference Include="FSharp.SystemTextJson" Version="1.3.13" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Hi,

I have some test projects using Faqt, and Visual Studio is highlighting transitive dependencies to System.Text.Json 6.0.6 through it which suffers from https://github.com/advisories/GHSA-8g4q-xg66-9fp4.

FracturedJson has now been updated to use System.Text.Json 6.0.10 which fixes the issue, so I wondered if there was interest in updating the dependency here to fix the warning?

Thanks.